### PR TITLE
Islam/axm 1660 tackle hapn requests over lambda extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GOOS=linux
+GOARCH=arm64
 
 build:
 	mkdir -p bin/extensions
@@ -8,7 +9,10 @@ package: build
 	cd bin && zip -r extension.zip extensions
 
 publish: package
-	aws lambda publish-layer-version --layer-name axiom-development-lambda-extension-go --region eu-west-1 --zip-file "fileb://bin/extension.zip" --compatible-architectures ${GOARCH}
+	aws lambda publish-layer-version --layer-name axiom-development-lambda-extension-go --region eu-west-1 --zip-file "fileb://bin/extension.zip" --compatible-architectures ${GOARCH} --description 'axiom lambda extension to push lambda logs to https://axiom.co' 
+
+arch:
+	echo ${GOARCH}
 
 clean:
 	rm -r ./bin

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -37,8 +37,8 @@ type NextEventResponse struct {
 }
 
 const (
-	extensionNameHeader      = "Lambda-Extension-Name"
-	extensionIdentiferHeader = "Lambda-Extension-Identifier"
+	extensionNameHeader       = "Lambda-Extension-Name"
+	extensionIdentifierHeader = "Lambda-Extension-Identifier"
 )
 
 func New(LogsAPI string) *Client {
@@ -85,7 +85,7 @@ func (c *Client) Register(ctx context.Context, extensionName string) (*RegisterR
 		return nil, err
 	}
 
-	c.ExtensionID = httpRes.Header.Get(extensionIdentiferHeader)
+	c.ExtensionID = httpRes.Header.Get(extensionIdentifierHeader)
 	return &RegRes, nil
 }
 
@@ -97,7 +97,7 @@ func (c *Client) NextEvent(ctx context.Context, extensionName string) (*NextEven
 	}
 
 	httpReq.Header.Set(extensionNameHeader, extensionName)
-	httpReq.Header.Set(extensionIdentiferHeader, c.ExtensionID)
+	httpReq.Header.Set(extensionIdentifierHeader, c.ExtensionID)
 
 	httpRes, err := c.httpClient.Do(httpReq)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -63,7 +63,9 @@ func Run() error {
 
 	axiom, err := flusher.New()
 	if err != nil {
-		return err
+		// don't return here, we want to run the parent layer even if axiom client creation fails, otherwise
+		// the layer will crash.
+		logger.Error("Error creating axiom client", zap.Error(err))
 	}
 
 	httpServer := server.New(logsPort, axiom, runtimeDone)

--- a/server/server.go
+++ b/server/server.go
@@ -100,7 +100,9 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 
 		// queue all the events at once to prevent locking and unlocking the mutex
 		// on each event
-		ax.QueueEvents(events)
+		if ax != nil {
+			ax.QueueEvents(events)
+		}
 		// inform the extension that platform.runtimeDone event has been received
 		if notifyRuntimeDone {
 			runtimeDone <- struct{}{}

--- a/server/server.go
+++ b/server/server.go
@@ -34,6 +34,7 @@ var (
 	AWS_LAMBDA_FUNCTION_MEMORY_SIZE, _ = strconv.ParseInt(os.Getenv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE"), 10, 32)
 	lambdaMetaInfo                     = map[string]any{}
 	axiomMetaInfo                      = map[string]string{}
+	appMetaInfo                        = map[string]string{}
 )
 
 func init() {
@@ -49,6 +50,10 @@ func init() {
 	}
 	axiomMetaInfo = map[string]string{
 		"awsLambdaExtensionVersion": version.Get(),
+	}
+	appMetaInfo = map[string]string{
+		"slug":    "axiom-lambda-extension",
+		"version": version.Get(),
 	}
 }
 
@@ -83,6 +88,7 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 			// attach the lambda information to the event
 			e["lambda"] = lambdaMetaInfo
 			e["axiom"] = axiomMetaInfo
+			e["@app"] = appMetaInfo
 			// replace the time field with axiom's _time
 			e["_time"], e["time"] = e["time"], nil
 

--- a/server/server.go
+++ b/server/server.go
@@ -100,9 +100,10 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 
 		// queue all the events at once to prevent locking and unlocking the mutex
 		// on each event
-		if ax != nil {
-			ax.QueueEvents(events)
-		}
+		flusher.SafelyUseAxiomClient(ax, func(client *flusher.Axiom) {
+			client.QueueEvents(events)
+		})
+
 		// inform the extension that platform.runtimeDone event has been received
 		if notifyRuntimeDone {
 			runtimeDone <- struct{}{}

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // manually set constant version
-const version string = "v3"
+const version string = "v5"
 
 // Get returns the Go module version of the axiom-go module.
 func Get() string {


### PR DESCRIPTION
The extension was crashing when the passed token is empty or invalid, leading to the extension returning error before it can register itself, and that crashes the main function as well.

I Expect the extension to not crash the main function.

The first solution that came to me is to not return an error and keep the extension running, that leads to  a panic from a reference to a nil pointer, which is the Axiom client in that case. The end result is me checking Axiom client is not null before calling it, not a smart solution, let me know if you have another idea to write this better.