### PR TITLE
parse json logs, duplicate record to message

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -92,7 +92,7 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 
 			if e["type"] == "function" {
 				e["message"] = e["record"]
-				if recordStr, ok := e["record"].(string); ok {
+				if recordStr, ok := e["record"].(string); ok && len(recordStr) > 0 {
 					recordStr = strings.Trim(recordStr, "\n")
 					// parse the record
 					// first check if the record is a json object, if not parse it as a text log line

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // manually set constant version
-const version string = "v9"
+const version string = "v10"
 
 // Get returns the Go module version of the axiom-go module.
 func Get() string {


### PR DESCRIPTION
created a new field called message which will always contain the original string that is in record field. The record field is parsed and converted to an object.