### PR TITLE
fix: fix missing lambda report log events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
 # Axiom Lambda Extension
 
-<a href="https://axiom.co">
-<picture>
-  <source media="(prefers-color-scheme: dark) and (min-width: 600px)" srcset="https://axiom.co/assets/github/axiom-github-banner-light-vertical.svg">
-  <source media="(prefers-color-scheme: light) and (min-width: 600px)" srcset="https://axiom.co/assets/github/axiom-github-banner-dark-vertical.svg">
-  <source media="(prefers-color-scheme: dark) and (max-width: 599px)" srcset="https://axiom.co/assets/github/axiom-github-banner-light-horizontal.svg">
-  <img alt="Axiom.co banner" src="https://axiom.co/assets/github/axiom-github-banner-dark-horizontal.svg" align="right">
-</picture>
-</a>
-&nbsp;
-
 Use Axiom Lambda Extension to send logs and platform events of your Lambda function to [Axiom](https://axiom.co/). Axiom detects the extension and provides you with quick filters and a dashboard.
 
 With the Axiom Lambda extension, you can forget about the extra configuration of CloudWatch and subscription filters.
+
+## Usage
+
+
+```sh
+aws lambda update-function-configuration --function-name my-function \
+    --layers arn:aws:lambda:AWS_REGION:694952825951:layer:axiom-extension-ARCH:VERSION
+```
 
 ## Documentation
 

--- a/decision/0001-no-wait-for-first-invocation.md
+++ b/decision/0001-no-wait-for-first-invocation.md
@@ -1,0 +1,23 @@
+author: Islam Shehata (@dasfmi)
+date: 2024-011-14
+---
+
+# No wait for first invocation
+
+## Background
+
+We had a mechanism in the extension that blocks execution until we receive the first invocation. This was done to ensure that the customers can
+receive logs for their first invocation. However, this was causing issues in some cases where the extension was not able to receive the first invocation
+and times out. 
+
+As this occurs more often, the invocation numbers in Axiom were significantly lower than the CloudWatch invocations.
+
+
+## Decision
+
+- Decided to remove the blocking mechanism and allow the extension to start processing logs as soon as it is invoked. This will ensure that the customers receive any incoming logs without any delay. Removal of the first invocation and the channel associated with it simplifies the extension and simplifies the workflow.
+- We had a function that checks if we should flush or not based on last time of flush. I replaced this function with a simple ticker instead, the ticker will tick every 1s and will flush the logs if the buffer is not empty. This will ensure that we are not blocking the logs for a long time.
+- We had two Axiom clients, one that retries and one that doesn't. I think it complicates things and we should have only one client that retries. We still need a mechanism to prevent infinite retries though, a circuit breaker or something.
+
+
+

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func Run() error {
 				}
 			})
 
-			// Wait for the first invocation to finish (receive platform.runtimeDone log), then flush
+			// Wait for the first invocation to finish (receive platform.report log), then flush
 			if isFirstInvocation {
 				<-runtimeDone
 				isFirstInvocation = false

--- a/server/server.go
+++ b/server/server.go
@@ -82,7 +82,7 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 
 		for _, e := range events {
 			e["message"] = ""
-			// if reocrd key exists, extract the requestId and message from it
+			// if record key exists, extract the requestId and message from it
 			if rec, ok := e["record"]; ok {
 				if record, ok := rec.(map[string]any); ok {
 					// capture requestId and set it if it exists
@@ -112,7 +112,7 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 			}
 
 			// decide if the handler should notify the extension that the runtime is done
-			if e["type"] == "platform.runtimeDone" && !firstInvocationDone {
+			if e["type"] == "platform.report" && !firstInvocationDone {
 				notifyRuntimeDone = true
 			}
 		}
@@ -123,7 +123,7 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 			client.QueueEvents(events)
 		})
 
-		// inform the extension that platform.runtimeDone event has been received
+		// inform the extension that platform.report event has been received
 		if notifyRuntimeDone {
 			runtimeDone <- struct{}{}
 			firstInvocationDone = true

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // manually set constant version
-const version string = "v11"
+const version string = "v12"
 
 // Get returns the Go module version of the axiom-go module.
 func Get() string {


### PR DESCRIPTION
This attempts to fix the missing `platform.report` log events by changing when the flusher should flush all logs. Will test this for couple of days internally.