### PR TITLE
Fix JSON parsing for Lambda function log records

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 
 	"os"
 	"strconv"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -24,6 +26,8 @@ var (
 	logger              *zap.Logger
 	firstInvocationDone = false
 )
+
+var logLineRgx = regexp.MustCompile(`^([0-9.:TZ-]{20,})\s+([0-9a-f-]{36})\s+(ERROR|INFO|WARN|DEBUG|TRACE)\s+(?s:(.*))`)
 
 // lambda environment variables
 var (
@@ -81,22 +85,9 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 		requestID := ""
 
 		for _, e := range events {
-			e["message"] = ""
-			// if reocrd key exists, extract the requestId and message from it
-			if rec, ok := e["record"]; ok {
-				if record, ok := rec.(map[string]any); ok {
-					// capture requestId and set it if it exists
-					if reqID, ok := record["requestId"]; ok {
-						if id, ok := reqID.(string); ok {
-							requestID = id
-						}
-					}
-					if e["type"] == "function" {
-						if msg, ok := record["message"].(string); ok {
-							// set message
-							e["message"] = msg
-						}
-					}
+			if record, ok := e["record"].(map[string]any); ok {
+				if id, ok := stringField(record, "requestId"); ok {
+					requestID = id
 				}
 			}
 
@@ -106,13 +97,8 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 			// replace the time field with axiom's _time
 			e["_time"], e["time"] = e["time"], nil
 
-			// If we didn't find a message in record field, move the record to message
-			// and assign requestId
-			if e["type"] == "function" && e["message"] == "" {
-				e["message"] = e["record"]
-				e["record"] = map[string]string{
-					"requestId": requestID,
-				}
+			if e["type"] == "function" {
+				requestID = extractEventMessage(e, requestID)
 			}
 
 			// decide if the handler should notify the extension that the runtime is done
@@ -135,4 +121,79 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 			close(runtimeDone)
 		}
 	}
+}
+
+// extractEventMessage normalizes Lambda function logs while preserving the raw
+// record value in message. String records may contain JSON even when Telemetry
+// API delivers them as text.
+func extractEventMessage(e map[string]any, requestID string) string {
+	recordValue, ok := e["record"]
+	if !ok {
+		e["message"] = ""
+		e["record"] = map[string]string{"requestId": requestID}
+		return requestID
+	}
+
+	e["message"] = recordValue
+
+	switch record := recordValue.(type) {
+	case map[string]any:
+		if id, ok := stringField(record, "requestId"); ok {
+			requestID = id
+		}
+		if msg, ok := stringField(record, "message"); ok {
+			e["message"] = msg
+		}
+		return requestID
+	case string:
+		return extractStringRecord(e, record, requestID)
+	default:
+		e["record"] = map[string]string{"requestId": requestID}
+		return requestID
+	}
+}
+
+func extractStringRecord(e map[string]any, recordStr string, requestID string) string {
+	trimmedRecord := strings.TrimSpace(recordStr)
+	if trimmedRecord == "" {
+		e["record"] = map[string]string{"requestId": requestID}
+		return requestID
+	}
+
+	if strings.HasPrefix(trimmedRecord, "{") && strings.HasSuffix(trimmedRecord, "}") {
+		var record map[string]any
+		if err := json.Unmarshal([]byte(trimmedRecord), &record); err != nil {
+			logger.Error("Error unmarshalling record:", zap.Error(err))
+		} else {
+			if level, ok := stringField(record, "level"); ok {
+				record["level"] = strings.ToLower(level)
+				e["level"] = record["level"]
+			}
+			if id, ok := stringField(record, "requestId"); ok {
+				requestID = id
+			}
+			e["record"] = record
+			return requestID
+		}
+	}
+
+	matches := logLineRgx.FindStringSubmatch(trimmedRecord)
+	if len(matches) == 5 {
+		e["level"] = strings.ToLower(matches[3])
+		e["record"] = map[string]any{
+			"requestId": matches[2],
+			"message":   matches[4],
+			"timestamp": matches[1],
+			"level":     e["level"],
+		}
+		return matches[2]
+	}
+
+	e["record"] = map[string]string{"requestId": requestID}
+	return requestID
+}
+
+func stringField(record map[string]any, key string) (string, bool) {
+	value, ok := record[key].(string)
+	return value, ok
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,120 @@
+package server
+
+import "testing"
+
+func TestExtractEventMessageParsesJSONRecordString(t *testing.T) {
+	rawRecord := `{"level":"INFO","env":"test_creds","app":"aall","requestId":"eb506e5d-e205-4747-870b-b85a48fc2f19","gatewayRequestId":"Root=1-69de4a4b-0d6b7a832500a9a9340fabb1","method":"GET","path":"/brands/cgra8memi4ohud77svp0/overview/2026-03-15/2026-04-14","handler_time_ms":80,"time":"2026-04-14T14:08:11Z","caller":"/home/runner/work/unify/unify/internal/middleware/timing.go:32","message":"request completed"}` + "\n"
+	event := map[string]any{
+		"type":   "function",
+		"record": rawRecord,
+	}
+
+	requestID := extractEventMessage(event, "platform-request-id")
+
+	if requestID != "eb506e5d-e205-4747-870b-b85a48fc2f19" {
+		t.Fatalf("expected requestID from parsed record, got %q", requestID)
+	}
+	if event["message"] != rawRecord {
+		t.Fatalf("expected message to preserve raw record")
+	}
+	if event["level"] != "info" {
+		t.Fatalf("expected top-level level to be normalized, got %v", event["level"])
+	}
+
+	record, ok := event["record"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected parsed record map, got %T", event["record"])
+	}
+
+	assertEqual(t, record["app"], "aall")
+	assertEqual(t, record["level"], "info")
+	assertEqual(t, record["message"], "request completed")
+	assertEqual(t, record["path"], "/brands/cgra8memi4ohud77svp0/overview/2026-03-15/2026-04-14")
+	assertEqual(t, record["requestId"], "eb506e5d-e205-4747-870b-b85a48fc2f19")
+}
+
+func TestExtractEventMessagePreservesStructuredTelemetryRecord(t *testing.T) {
+	inputRecord := map[string]any{
+		"requestId": "structured-request-id",
+		"message":   "request completed",
+		"level":     "info",
+	}
+	event := map[string]any{
+		"type":   "function",
+		"record": inputRecord,
+	}
+
+	requestID := extractEventMessage(event, "platform-request-id")
+
+	if requestID != "structured-request-id" {
+		t.Fatalf("expected requestID from structured record, got %q", requestID)
+	}
+	if event["message"] != "request completed" {
+		t.Fatalf("expected message from structured record, got %v", event["message"])
+	}
+	record, ok := event["record"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected structured record map, got %T", event["record"])
+	}
+	assertEqual(t, record["requestId"], "structured-request-id")
+	assertEqual(t, record["message"], "request completed")
+	assertEqual(t, record["level"], "info")
+}
+
+func TestExtractEventMessageFallsBackForPlainStringRecord(t *testing.T) {
+	event := map[string]any{
+		"type":   "function",
+		"record": "plain log line",
+	}
+
+	requestID := extractEventMessage(event, "platform-request-id")
+
+	if requestID != "platform-request-id" {
+		t.Fatalf("expected existing requestID to be preserved, got %q", requestID)
+	}
+	if event["message"] != "plain log line" {
+		t.Fatalf("expected message to preserve plain log line, got %v", event["message"])
+	}
+
+	record, ok := event["record"].(map[string]string)
+	if !ok {
+		t.Fatalf("expected fallback record map, got %T", event["record"])
+	}
+	assertEqual(t, record["requestId"], "platform-request-id")
+}
+
+func TestExtractEventMessageParsesAWSLogLine(t *testing.T) {
+	rawRecord := "2024-01-16T08:53:51.919Z\t4b995efa-75f8-4fdc-92af-0882c79f47a1\tERROR\ttesting sending an error\nand this is a new line inside the error"
+	event := map[string]any{
+		"type":   "function",
+		"record": rawRecord,
+	}
+
+	requestID := extractEventMessage(event, "")
+
+	if requestID != "4b995efa-75f8-4fdc-92af-0882c79f47a1" {
+		t.Fatalf("expected requestID from parsed log line, got %q", requestID)
+	}
+	if event["message"] != rawRecord {
+		t.Fatalf("expected message to preserve raw log line")
+	}
+	if event["level"] != "error" {
+		t.Fatalf("expected parsed level, got %v", event["level"])
+	}
+
+	record, ok := event["record"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected parsed log line record map, got %T", event["record"])
+	}
+	assertEqual(t, record["requestId"], "4b995efa-75f8-4fdc-92af-0882c79f47a1")
+	assertEqual(t, record["level"], "error")
+	assertEqual(t, record["message"], "testing sending an error\nand this is a new line inside the error")
+	assertEqual(t, record["timestamp"], "2024-01-16T08:53:51.919Z")
+}
+
+func assertEqual(t *testing.T, got, want any) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- Restore parsing for JSON strings delivered in Lambda Telemetry API `record` fields.
- Preserve native structured Telemetry API records while keeping raw string records in `message`.
- Restore AWS log-line parsing for request ID, message, timestamp, and normalized level extraction.
- Add regression coverage for JSON string records, structured records, plain strings, and AWS log lines.

## Testing
- `go test ./...`
- `go test ./server -run TestExtractEventMessage -count=1 -v`
- `GOOS=linux GOARCH=amd64 go build -o /tmp/axiom-lambda-extension-test-amd64 .`
- `GOOS=linux GOARCH=arm64 go build -o /tmp/axiom-lambda-extension-test-arm64 .`