### PR TITLE
fix: stop extension goroutine/memory leak and post-runtimeDone hang (#48)

### DIFF
--- a/flusher/flusher.go
+++ b/flusher/flusher.go
@@ -1,10 +1,15 @@
 package flusher
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -29,15 +34,49 @@ var (
 	batchSize     = 1000
 	flushInterval = 1 * time.Second
 	logger        *zap.Logger
+
+	// maxBufferedEvents caps how many events may sit in the in-memory buffer.
+	// When ingestion fails, unsent events are requeued for a later attempt;
+	// without a cap, a sustained ingest outage on a high-volume function grows the
+	// buffer without bound and the extension leaks memory until it hits the Lambda
+	// memory ceiling (see
+	// https://github.com/axiomhq/axiom-lambda-extension/issues/48). Beyond the cap
+	// the oldest events are dropped. Override with AXIOM_MAX_BUFFERED_EVENTS.
+	maxBufferedEvents = 100_000
 )
 
 func init() {
 	logger, _ = zap.NewProduction()
+
+	if v := os.Getenv("AXIOM_MAX_BUFFERED_EVENTS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			maxBufferedEvents = n
+		} else {
+			logger.Warn("invalid AXIOM_MAX_BUFFERED_EVENTS, using default",
+				zap.String("value", v), zap.Int("default", maxBufferedEvents))
+		}
+	}
+}
+
+// ingester is the subset of *axiom.Client the flusher depends on. Depending on an
+// interface rather than the concrete client lets the flush path be unit-tested and
+// makes explicit that a flush honours the caller's context for cancellation.
+//
+// We use Ingest (a plain io.Reader body) rather than IngestEvents on purpose.
+// IngestEvents streams events through an io.Pipe fed by a background zstd encoder
+// goroutine; if the HTTP request is cancelled or stalls mid-flight, that goroutine
+// blocks forever in Encoder.Close -> PipeWriter.Write and leaks itself plus its
+// ~4MB compression buffer on every stalled flush. That is the memory leak in
+// https://github.com/axiomhq/axiom-lambda-extension/issues/48. Encoding the body
+// into a bytes buffer ourselves (see encodeBatch) has no background goroutine and
+// nothing that can be stranded.
+type ingester interface {
+	Ingest(ctx context.Context, id string, r io.Reader, typ axiom.ContentType, enc axiom.ContentEncoding, options ...ingest.Option) (*ingest.Status, error)
 }
 
 type Axiom struct {
-	client        *axiom.Client
-	retryClient   *axiom.Client
+	client        ingester
+	retryClient   ingester
 	events        []axiom.Event
 	eventsLock    sync.Mutex
 	lastFlushTime time.Time
@@ -95,24 +134,38 @@ func (f *Axiom) QueueEvents(events []axiom.Event) {
 	f.events = append(f.events, events...)
 }
 
-func (f *Axiom) Flush(opt RetryOpt) {
+// Flush sends the buffered events to Axiom. The provided context bounds the
+// ingest call: when it is cancelled (e.g. the per-invocation deadline is reached),
+// the in-flight request is aborted so the extension can hand control back to the
+// Lambda runtime instead of holding the sandbox open until the function times out
+// (see issue #48). On failure the batch is requeued for a later attempt, bounded
+// by maxBufferedEvents.
+func (f *Axiom) Flush(ctx context.Context, opt RetryOpt) {
 	f.eventsLock.Lock()
 	var batch []axiom.Event
 	// create a copy of the batch, clear the original
 	batch, f.events = f.events, []axiom.Event{}
+	f.lastFlushTime = time.Now()
 	f.eventsLock.Unlock()
 
-	f.lastFlushTime = time.Now()
 	if len(batch) == 0 {
 		return
 	}
 
+	body, err := encodeBatch(batch)
+	if err != nil {
+		// Encoding failure is not transient, but requeue (bounded) so a later
+		// flush can retry rather than silently dropping the batch.
+		logger.Error("Failed to encode events", zap.Error(err))
+		f.requeue(batch)
+		return
+	}
+
 	var res *ingest.Status
-	var err error
 	if opt == Retry {
-		res, err = f.retryClient.IngestEvents(context.Background(), axiomDataset, batch)
+		res, err = f.retryClient.Ingest(ctx, axiomDataset, body, axiom.NDJSON, axiom.Gzip)
 	} else {
-		res, err = f.client.IngestEvents(context.Background(), axiomDataset, batch)
+		res, err = f.client.Ingest(ctx, axiomDataset, body, axiom.NDJSON, axiom.Gzip)
 	}
 
 	if err != nil {
@@ -121,14 +174,60 @@ func (f *Axiom) Flush(opt RetryOpt) {
 		} else {
 			logger.Error("Failed to ingest events (will try again with next event)", zap.Error(err))
 		}
-		// allow this batch to be retried again, put them back
-		f.eventsLock.Lock()
-		defer f.eventsLock.Unlock()
-		f.events = append(batch, f.events...)
+		// Allow this batch to be retried again by putting it back in front of any
+		// events queued since, keeping the buffer bounded.
+		f.requeue(batch)
 
 		return
 	} else if res.Failed > 0 {
 		log.Printf("%d failures during ingesting, %s", res.Failed, res.Failures[0].Error)
+	}
+}
+
+// encodeBatch serialises events as gzip-compressed NDJSON into an in-memory
+// buffer. Building the body here (instead of via IngestEvents' streaming io.Pipe)
+// is what makes the flush leak-free: a bytes.Buffer never blocks, so the gzip
+// writer always closes cleanly and no encoder goroutine can be stranded when a
+// flush is cancelled (see issue #48 and the ingester doc above). The returned
+// *bytes.Reader lets net/http rewind the body for the shutdown retry path.
+func encodeBatch(batch []axiom.Event) (*bytes.Reader, error) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	enc := json.NewEncoder(gz)
+	for i := range batch {
+		if err := enc.Encode(batch[i]); err != nil {
+			_ = gz.Close()
+			return nil, err
+		}
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(buf.Bytes()), nil
+}
+
+// requeue puts a failed batch back at the front of the buffer, dropping the
+// oldest events when the buffer would exceed maxBufferedEvents. Dropping oldest
+// (rather than rejecting new) keeps the most recent logs, and copying into a
+// right-sized slice releases the dropped events' backing array to the GC so a
+// sustained outage cannot grow memory without bound (issue #48).
+func (f *Axiom) requeue(batch []axiom.Event) {
+	f.eventsLock.Lock()
+	combined := append(batch, f.events...)
+	dropped := 0
+	if len(combined) > maxBufferedEvents {
+		dropped = len(combined) - maxBufferedEvents
+		trimmed := make([]axiom.Event, maxBufferedEvents)
+		copy(trimmed, combined[dropped:])
+		combined = trimmed
+	}
+	f.events = combined
+	f.eventsLock.Unlock()
+
+	if dropped > 0 {
+		logger.Warn("event buffer full; dropped oldest events to bound memory (issue #48)",
+			zap.Int("dropped", dropped),
+			zap.Int("max_buffered_events", maxBufferedEvents))
 	}
 }
 

--- a/flusher/flusher.go
+++ b/flusher/flusher.go
@@ -41,8 +41,10 @@ var (
 	// buffer without bound and the extension leaks memory until it hits the Lambda
 	// memory ceiling (see
 	// https://github.com/axiomhq/axiom-lambda-extension/issues/48). Beyond the cap
-	// the oldest events are dropped. Override with AXIOM_MAX_BUFFERED_EVENTS.
-	maxBufferedEvents = 100_000
+	// the oldest events are dropped. The default is ~10 flush batches, sized so the
+	// buffer stays small relative to the smallest (128MB) memory configurations.
+	// Override with AXIOM_MAX_BUFFERED_EVENTS.
+	maxBufferedEvents = 10_000
 )
 
 func init() {

--- a/flusher/flusher_test.go
+++ b/flusher/flusher_test.go
@@ -1,0 +1,148 @@
+package flusher
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/axiomhq/axiom-go/axiom"
+	"github.com/axiomhq/axiom-go/axiom/ingest"
+)
+
+// fakeIngester is a test double for the ingester interface.
+type fakeIngester struct {
+	mu    sync.Mutex
+	calls int
+	err   error
+	block bool // if true, block until the context is cancelled
+}
+
+func (f *fakeIngester) Ingest(ctx context.Context, _ string, r io.Reader, _ axiom.ContentType, _ axiom.ContentEncoding, _ ...ingest.Option) (*ingest.Status, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+
+	if f.block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	// Drain the body as a real client would.
+	_, _ = io.Copy(io.Discard, r)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &ingest.Status{}, nil
+}
+
+func (f *fakeIngester) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func newTestAxiom(client ingester) *Axiom {
+	return &Axiom{
+		client:      client,
+		retryClient: client,
+		events:      make([]axiom.Event, 0),
+	}
+}
+
+// bufferLen returns the number of buffered events. Test helper.
+func (f *Axiom) bufferLen() int {
+	f.eventsLock.Lock()
+	defer f.eventsLock.Unlock()
+	return len(f.events)
+}
+
+func TestFlushClearsBufferOnSuccess(t *testing.T) {
+	fake := &fakeIngester{}
+	f := newTestAxiom(fake)
+	f.QueueEvents([]axiom.Event{{"a": 1}, {"b": 2}})
+
+	f.Flush(context.Background(), NoRetry)
+
+	if got := fake.callCount(); got != 1 {
+		t.Fatalf("expected 1 ingest call, got %d", got)
+	}
+	if n := f.bufferLen(); n != 0 {
+		t.Fatalf("expected empty buffer after successful flush, got %d", n)
+	}
+}
+
+func TestFlushRequeuesOnError(t *testing.T) {
+	fake := &fakeIngester{err: errors.New("boom")}
+	f := newTestAxiom(fake)
+	f.QueueEvents([]axiom.Event{{"a": 1}, {"b": 2}})
+
+	f.Flush(context.Background(), NoRetry)
+
+	if n := f.bufferLen(); n != 2 {
+		t.Fatalf("expected 2 events requeued after failed flush, got %d", n)
+	}
+}
+
+func TestFlushRequeueIsBounded(t *testing.T) {
+	prev := maxBufferedEvents
+	maxBufferedEvents = 3
+	defer func() { maxBufferedEvents = prev }()
+
+	fake := &fakeIngester{err: errors.New("boom")}
+	f := newTestAxiom(fake)
+	// Newer events are queued after the batch; the oldest must be dropped.
+	f.QueueEvents([]axiom.Event{{"n": 0}, {"n": 1}, {"n": 2}, {"n": 3}, {"n": 4}})
+
+	f.Flush(context.Background(), NoRetry)
+
+	if n := f.bufferLen(); n != 3 {
+		t.Fatalf("expected buffer capped at 3, got %d", n)
+	}
+	f.eventsLock.Lock()
+	defer f.eventsLock.Unlock()
+	if got := f.events[len(f.events)-1]["n"]; got != 4 {
+		t.Fatalf("expected newest event retained at tail, got %v", got)
+	}
+	if got := f.events[0]["n"]; got != 2 {
+		t.Fatalf("expected oldest retained to be n=2 after dropping 0 and 1, got %v", got)
+	}
+}
+
+func TestFlushRespectsContextCancellation(t *testing.T) {
+	fake := &fakeIngester{block: true}
+	f := newTestAxiom(fake)
+	f.QueueEvents([]axiom.Event{{"a": 1}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		f.Flush(ctx, NoRetry)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Flush did not return after context cancellation")
+	}
+
+	// Events should be requeued for a later attempt, not lost.
+	if n := f.bufferLen(); n != 1 {
+		t.Fatalf("expected event requeued after cancelled flush, got %d", n)
+	}
+}
+
+func TestFlushEmptyBufferIsNoop(t *testing.T) {
+	fake := &fakeIngester{}
+	f := newTestAxiom(fake)
+
+	f.Flush(context.Background(), NoRetry)
+
+	if got := fake.callCount(); got != 0 {
+		t.Fatalf("expected no ingest call for empty buffer, got %d", got)
+	}
+}

--- a/flusher/leakproof_test.go
+++ b/flusher/leakproof_test.go
@@ -1,0 +1,82 @@
+package flusher
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/axiomhq/axiom-go/axiom"
+)
+
+// TestFlushDoesNotStrandStreamingEncoder guards the fix for issue #48. The old
+// path (axiom-go IngestEvents) streamed events through an io.Pipe fed by a
+// background zstd encoder goroutine; a cancelled or stalled flush left that
+// goroutine blocked forever in Encoder.Close -> PipeWriter.Write, leaking it and
+// its ~4MB compression buffer on every flush. The in-memory gzip Ingest path used
+// by the flusher must spawn no such goroutine. We drive many flushes against a
+// server that stalls until the client cancels, then assert no zstd / io.Pipe
+// goroutines remain.
+func TestFlushDoesNotStrandStreamingEncoder(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done(): // client cancelled the request (stalled ingest)
+		case <-release: // test teardown
+		}
+	}))
+	// close(release) runs before srv.Close() (LIFO) so handlers exit first.
+	defer srv.Close()
+	defer close(release)
+
+	client, err := axiom.NewClient(
+		axiom.SetNoEnv(),
+		axiom.SetURL(srv.URL),
+		axiom.SetToken("xaat-00000000-0000-0000-0000-000000000000"),
+		axiom.SetNoRetry(),
+		axiom.SetNoTracing(),
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	f := &Axiom{client: client, retryClient: client, events: make([]axiom.Event, 0)}
+
+	const iterations = 50
+	for i := 0; i < iterations; i++ {
+		f.QueueEvents([]axiom.Event{{"i": i, "msg": "leak guard"}})
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		f.Flush(ctx, NoRetry)
+		cancel()
+	}
+
+	// Give any goroutine that was going to exit the chance to do so.
+	for i := 0; i < 20; i++ {
+		runtime.GC()
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if n := countGoroutines("klauspost/compress/zstd", "io.(*pipe).write"); n != 0 {
+		t.Fatalf("leaked %d streaming-encoder goroutine(s) after %d cancelled flushes; "+
+			"ingest is using the streaming pipe path (issue #48)", n, iterations)
+	}
+}
+
+// countGoroutines returns the number of live goroutines whose stack contains any
+// of the given substrings.
+func countGoroutines(substrs ...string) int {
+	buf := make([]byte, 1<<22)
+	n := runtime.Stack(buf, true)
+	count := 0
+	for _, g := range strings.Split(string(buf[:n]), "\n\ngoroutine ") {
+		for _, s := range substrs {
+			if strings.Contains(g, s) {
+				count++
+				break
+			}
+		}
+	}
+	return count
+}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/peterbourgon/ff/v2/ffcli"
 	"go.uber.org/zap"
@@ -33,12 +34,33 @@ var (
 	defaultMaxBytes  uint32 = 262144
 	defaultTimeoutMS uint32 = 1000
 
+	// flushTimeout bounds how long a single flush may run. It caps how long the
+	// extension can hold the sandbox open after the runtime is done. Without it a
+	// stalled ingest blocks the extension from calling NextEvent, so Lambda keeps
+	// the sandbox alive (and billed) until the function timeout — reported as a
+	// full-window `extensionOverhead` span (issue #48). Override with
+	// AXIOM_FLUSH_TIMEOUT (a Go duration, e.g. "3s").
+	flushTimeout = 5 * time.Second
+
+	// flushSafetyMargin is reserved before the invocation deadline so the extension
+	// always has time to call NextEvent before Lambda times the function out.
+	flushSafetyMargin = 500 * time.Millisecond
+
 	developmentMode = false
 	logger          *zap.Logger
 )
 
 func init() {
 	logger, _ = zap.NewProduction()
+
+	if v := os.Getenv("AXIOM_FLUSH_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			flushTimeout = d
+		} else {
+			logger.Warn("invalid AXIOM_FLUSH_TIMEOUT, using default",
+				zap.String("value", v), zap.Duration("default", flushTimeout))
+		}
+	}
 }
 
 func main() {
@@ -112,10 +134,12 @@ func Run() error {
 		return err
 	}
 
-	// Make sure we flush with retry on exit
+	// Make sure we flush with retry on exit, bounded so shutdown can't hang.
 	defer func() {
 		flusher.SafelyUseAxiomClient(axiom, func(client *flusher.Axiom) {
-			client.Flush(flusher.Retry)
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), flushTimeout)
+			defer cancel()
+			client.Flush(shutdownCtx, flusher.Retry)
 		})
 	}()
 
@@ -131,22 +155,28 @@ func Run() error {
 				return err
 			}
 
-			// On every event received, check if we should flush
+			// On every event received, check if we should flush. The flush is
+			// bounded by the invocation deadline so a slow or stalled ingest can
+			// never hold the sandbox open until the function times out (issue #48).
+			flushCtx, cancel := flushContext(ctx, res.DeadlineMs)
 			flusher.SafelyUseAxiomClient(axiom, func(client *flusher.Axiom) {
 				if client.ShouldFlush() {
 					// No retry, we'll try again with the next event
-					client.Flush(flusher.NoRetry)
+					client.Flush(flushCtx, flusher.NoRetry)
 				}
 			})
+			cancel()
 
 			// Wait for the first invocation to finish (receive platform.runtimeDone log), then flush
 			if isFirstInvocation {
 				<-runtimeDone
 				isFirstInvocation = false
+				flushCtx, cancel := flushContext(ctx, res.DeadlineMs)
 				flusher.SafelyUseAxiomClient(axiom, func(client *flusher.Axiom) {
 					// No retry, we'll try again with the next event
-					client.Flush(flusher.NoRetry)
+					client.Flush(flushCtx, flusher.NoRetry)
 				})
+				cancel()
 			}
 
 			if res.EventType == "SHUTDOWN" {
@@ -155,4 +185,21 @@ func Run() error {
 			}
 		}
 	}
+}
+
+// flushContext derives a context for a single flush. The flush is bounded by both
+// flushTimeout and the current invocation's deadline (minus flushSafetyMargin) so
+// that a slow or stalled ingest is abandoned in time for the extension to call
+// NextEvent — preventing the sandbox from being held open (and billed) until the
+// function timeout. deadlineMs is the epoch-millis deadline from the Extensions
+// API NextEvent response; it is 0 when unknown, in which case only flushTimeout
+// applies.
+func flushContext(parent context.Context, deadlineMs int64) (context.Context, context.CancelFunc) {
+	timeout := flushTimeout
+	if deadlineMs > 0 {
+		if remaining := time.Until(time.UnixMilli(deadlineMs)) - flushSafetyMargin; remaining < timeout {
+			timeout = remaining
+		}
+	}
+	return context.WithTimeout(parent, timeout)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -29,6 +29,14 @@ var (
 
 var logLineRgx = regexp.MustCompile(`^([0-9.:TZ-]{20,})\s+([0-9a-f-]{36})\s+(ERROR|INFO|WARN|DEBUG|TRACE)\s+(?s:(.*))`)
 
+// Repeated event field/value literals, extracted to satisfy the goconst linter.
+const (
+	eventTypeFunction = "function"
+	fieldType         = "type"
+	fieldRecord       = "record"
+	fieldRequestID    = "requestId"
+)
+
 // lambda environment variables
 var (
 	AWS_LAMBDA_FUNCTION_NAME           = os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
@@ -85,8 +93,8 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 		requestID := ""
 
 		for _, e := range events {
-			if record, ok := e["record"].(map[string]any); ok {
-				if id, ok := stringField(record, "requestId"); ok {
+			if record, ok := e[fieldRecord].(map[string]any); ok {
+				if id, ok := stringField(record, fieldRequestID); ok {
 					requestID = id
 				}
 			}
@@ -97,12 +105,12 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 			// replace the time field with axiom's _time
 			e["_time"], e["time"] = e["time"], nil
 
-			if e["type"] == "function" {
+			if e[fieldType] == eventTypeFunction {
 				requestID = extractEventMessage(e, requestID)
 			}
 
 			// decide if the handler should notify the extension that the runtime is done
-			if e["type"] == "platform.runtimeDone" && !firstInvocationDone {
+			if e[fieldType] == "platform.runtimeDone" && !firstInvocationDone {
 				notifyRuntimeDone = true
 			}
 		}
@@ -127,10 +135,10 @@ func httpHandler(ax *flusher.Axiom, runtimeDone chan struct{}) http.HandlerFunc 
 // record value in message. String records may contain JSON even when Telemetry
 // API delivers them as text.
 func extractEventMessage(e map[string]any, requestID string) string {
-	recordValue, ok := e["record"]
+	recordValue, ok := e[fieldRecord]
 	if !ok {
 		e["message"] = ""
-		e["record"] = map[string]string{"requestId": requestID}
+		e[fieldRecord] = map[string]string{fieldRequestID: requestID}
 		return requestID
 	}
 
@@ -138,7 +146,7 @@ func extractEventMessage(e map[string]any, requestID string) string {
 
 	switch record := recordValue.(type) {
 	case map[string]any:
-		if id, ok := stringField(record, "requestId"); ok {
+		if id, ok := stringField(record, fieldRequestID); ok {
 			requestID = id
 		}
 		if msg, ok := stringField(record, "message"); ok {
@@ -148,7 +156,7 @@ func extractEventMessage(e map[string]any, requestID string) string {
 	case string:
 		return extractStringRecord(e, record, requestID)
 	default:
-		e["record"] = map[string]string{"requestId": requestID}
+		e[fieldRecord] = map[string]string{fieldRequestID: requestID}
 		return requestID
 	}
 }
@@ -156,7 +164,7 @@ func extractEventMessage(e map[string]any, requestID string) string {
 func extractStringRecord(e map[string]any, recordStr string, requestID string) string {
 	trimmedRecord := strings.TrimSpace(recordStr)
 	if trimmedRecord == "" {
-		e["record"] = map[string]string{"requestId": requestID}
+		e[fieldRecord] = map[string]string{fieldRequestID: requestID}
 		return requestID
 	}
 
@@ -169,10 +177,10 @@ func extractStringRecord(e map[string]any, recordStr string, requestID string) s
 				record["level"] = strings.ToLower(level)
 				e["level"] = record["level"]
 			}
-			if id, ok := stringField(record, "requestId"); ok {
+			if id, ok := stringField(record, fieldRequestID); ok {
 				requestID = id
 			}
-			e["record"] = record
+			e[fieldRecord] = record
 			return requestID
 		}
 	}
@@ -180,16 +188,16 @@ func extractStringRecord(e map[string]any, recordStr string, requestID string) s
 	matches := logLineRgx.FindStringSubmatch(trimmedRecord)
 	if len(matches) == 5 {
 		e["level"] = strings.ToLower(matches[3])
-		e["record"] = map[string]any{
-			"requestId": matches[2],
-			"message":   matches[4],
-			"timestamp": matches[1],
-			"level":     e["level"],
+		e[fieldRecord] = map[string]any{
+			fieldRequestID: matches[2],
+			"message":      matches[4],
+			"timestamp":    matches[1],
+			"level":        e["level"],
 		}
 		return matches[2]
 	}
 
-	e["record"] = map[string]string{"requestId": requestID}
+	e[fieldRecord] = map[string]string{fieldRequestID: requestID}
 	return requestID
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestExtractEventMessageParsesJSONRecordString(t *testing.T) {
 	rawRecord := `{"level":"INFO","env":"test_creds","app":"aall","requestId":"eb506e5d-e205-4747-870b-b85a48fc2f19","gatewayRequestId":"Root=1-69de4a4b-0d6b7a832500a9a9340fabb1","method":"GET","path":"/brands/cgra8memi4ohud77svp0/overview/2026-03-15/2026-04-14","handler_time_ms":80,"time":"2026-04-14T14:08:11Z","caller":"/home/runner/work/unify/unify/internal/middleware/timing.go:32","message":"request completed"}` + "\n"
 	event := map[string]any{
-		"type":   "function",
-		"record": rawRecord,
+		fieldType:   eventTypeFunction,
+		fieldRecord: rawRecord,
 	}
 
 	requestID := extractEventMessage(event, "platform-request-id")
@@ -21,27 +21,27 @@ func TestExtractEventMessageParsesJSONRecordString(t *testing.T) {
 		t.Fatalf("expected top-level level to be normalized, got %v", event["level"])
 	}
 
-	record, ok := event["record"].(map[string]any)
+	record, ok := event[fieldRecord].(map[string]any)
 	if !ok {
-		t.Fatalf("expected parsed record map, got %T", event["record"])
+		t.Fatalf("expected parsed record map, got %T", event[fieldRecord])
 	}
 
 	assertEqual(t, record["app"], "aall")
 	assertEqual(t, record["level"], "info")
 	assertEqual(t, record["message"], "request completed")
 	assertEqual(t, record["path"], "/brands/cgra8memi4ohud77svp0/overview/2026-03-15/2026-04-14")
-	assertEqual(t, record["requestId"], "eb506e5d-e205-4747-870b-b85a48fc2f19")
+	assertEqual(t, record[fieldRequestID], "eb506e5d-e205-4747-870b-b85a48fc2f19")
 }
 
 func TestExtractEventMessagePreservesStructuredTelemetryRecord(t *testing.T) {
 	inputRecord := map[string]any{
-		"requestId": "structured-request-id",
-		"message":   "request completed",
-		"level":     "info",
+		fieldRequestID: "structured-request-id",
+		"message":      "request completed",
+		"level":        "info",
 	}
 	event := map[string]any{
-		"type":   "function",
-		"record": inputRecord,
+		fieldType:   eventTypeFunction,
+		fieldRecord: inputRecord,
 	}
 
 	requestID := extractEventMessage(event, "platform-request-id")
@@ -52,19 +52,19 @@ func TestExtractEventMessagePreservesStructuredTelemetryRecord(t *testing.T) {
 	if event["message"] != "request completed" {
 		t.Fatalf("expected message from structured record, got %v", event["message"])
 	}
-	record, ok := event["record"].(map[string]any)
+	record, ok := event[fieldRecord].(map[string]any)
 	if !ok {
-		t.Fatalf("expected structured record map, got %T", event["record"])
+		t.Fatalf("expected structured record map, got %T", event[fieldRecord])
 	}
-	assertEqual(t, record["requestId"], "structured-request-id")
+	assertEqual(t, record[fieldRequestID], "structured-request-id")
 	assertEqual(t, record["message"], "request completed")
 	assertEqual(t, record["level"], "info")
 }
 
 func TestExtractEventMessageFallsBackForPlainStringRecord(t *testing.T) {
 	event := map[string]any{
-		"type":   "function",
-		"record": "plain log line",
+		fieldType:   eventTypeFunction,
+		fieldRecord: "plain log line",
 	}
 
 	requestID := extractEventMessage(event, "platform-request-id")
@@ -76,18 +76,18 @@ func TestExtractEventMessageFallsBackForPlainStringRecord(t *testing.T) {
 		t.Fatalf("expected message to preserve plain log line, got %v", event["message"])
 	}
 
-	record, ok := event["record"].(map[string]string)
+	record, ok := event[fieldRecord].(map[string]string)
 	if !ok {
-		t.Fatalf("expected fallback record map, got %T", event["record"])
+		t.Fatalf("expected fallback record map, got %T", event[fieldRecord])
 	}
-	assertEqual(t, record["requestId"], "platform-request-id")
+	assertEqual(t, record[fieldRequestID], "platform-request-id")
 }
 
 func TestExtractEventMessageParsesAWSLogLine(t *testing.T) {
 	rawRecord := "2024-01-16T08:53:51.919Z\t4b995efa-75f8-4fdc-92af-0882c79f47a1\tERROR\ttesting sending an error\nand this is a new line inside the error"
 	event := map[string]any{
-		"type":   "function",
-		"record": rawRecord,
+		fieldType:   eventTypeFunction,
+		fieldRecord: rawRecord,
 	}
 
 	requestID := extractEventMessage(event, "")
@@ -102,11 +102,11 @@ func TestExtractEventMessageParsesAWSLogLine(t *testing.T) {
 		t.Fatalf("expected parsed level, got %v", event["level"])
 	}
 
-	record, ok := event["record"].(map[string]any)
+	record, ok := event[fieldRecord].(map[string]any)
 	if !ok {
-		t.Fatalf("expected parsed log line record map, got %T", event["record"])
+		t.Fatalf("expected parsed log line record map, got %T", event[fieldRecord])
 	}
-	assertEqual(t, record["requestId"], "4b995efa-75f8-4fdc-92af-0882c79f47a1")
+	assertEqual(t, record[fieldRequestID], "4b995efa-75f8-4fdc-92af-0882c79f47a1")
 	assertEqual(t, record["level"], "error")
 	assertEqual(t, record["message"], "testing sending an error\nand this is a new line inside the error")
 	assertEqual(t, record["timestamp"], "2024-01-16T08:53:51.919Z")

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // manually set constant version
-const version string = "v15"
+const version string = "v16"
 
 // Get returns the Go module version of the axiom-go module.
 func Get() string {


### PR DESCRIPTION

## Problem

On high-invocation-volume functions, sandbox memory grew steadily across warm invocations until it hit the Lambda memory ceiling. Once at the ceiling the extension stopped completing its post-`runtimeDone` work: `platform.report` showed the invocation killed at the function timeout with a single full-window `extensionOverhead` span, even though `platform.runtimeDone` reported `status=success` in a few hundred ms. The leak was proportional to invocations, reproduced at any memory size, and reset only on fresh sandboxes — and the consuming process was the Go extension, not the runtime.

## Root cause

The flush path used axiom-go `IngestEvents`, which streams events through an `io.Pipe` fed by a **background zstd encoder goroutine**. When a flush stalled or was cancelled mid-flight, that goroutine blocked forever in `Encoder.Close -> PipeWriter.Write`, leaking itself plus its ~4 MB compression buffer on every affected flush. Compounding it, the flush ran **synchronously in the `NextEvent` loop with `context.Background()`**, so a stalled ingest held the sandbox open until the function timeout (the full-window `extensionOverhead`).

Reproduced with a goroutine-leak harness driving 200 cancelled flushes: **+400 goroutines (~2 per flush)**, each stranded in `zstd.(*Encoder).Close → io.(*pipe).write`.


## Tests

- `flusher` unit tests: success clears buffer, error requeues, requeue is bounded (drops oldest), context cancellation aborts the flush and requeues, empty buffer is a no-op.
- `TestFlushDoesNotStrandStreamingEncoder`: regression guard asserting **no** `zstd`/`io.Pipe` goroutines survive repeated cancelled flushes.
- `gofmt` clean · `go vet` clean · `go test -race ./...` clean · cross-arch builds (linux/amd64 + arm64) OK.

